### PR TITLE
Napo and Friends

### DIFF
--- a/config/sync/block.block.exposedformnapo_films_indexpage_1.yml
+++ b/config/sync/block.block.exposedformnapo_films_indexpage_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: exposedformnapo_films_indexpage_1
 theme: napo_theme
 region: content
-weight: -13
+weight: -12
 provider: null
 plugin: 'views_exposed_filter_block:napo_films_index-page_1'
 settings:

--- a/config/sync/block.block.quicktabsnapoandfriends.yml
+++ b/config/sync/block.block.quicktabsnapoandfriends.yml
@@ -1,0 +1,33 @@
+uuid: c1353e78-4d24-4e68-b5dc-9349213b36a1
+langcode: en
+status: false
+dependencies:
+  module:
+    - quicktabs
+    - system
+    - user
+  theme:
+    - napo_theme
+id: quicktabsnapoandfriends
+theme: napo_theme
+region: content
+weight: -13
+provider: null
+plugin: 'quicktabs_block:napo_and_friends'
+settings:
+  id: 'quicktabs_block:napo_and_friends'
+  label: 'QuickTabs - Napo and friends'
+  provider: quicktabs
+  label_display: '0'
+visibility:
+  request_path:
+    id: request_path
+    pages: "/about-napo/napo-and-friends\r\n/about-napo/napo-and-friends/view\r\n/about-napo/napo-and-friends/reorder"
+    negate: false
+  user_role:
+    id: user_role
+    roles:
+      administrator: administrator
+    negate: false
+    context_mapping:
+      user: '@user.current_user_context:current_user'

--- a/config/sync/quicktabs.quicktabs_instance.napo_and_friends.yml
+++ b/config/sync/quicktabs.quicktabs_instance.napo_and_friends.yml
@@ -1,0 +1,61 @@
+uuid: e6a2a9cb-07d9-4430-9f73-09c6a088eedb
+langcode: en
+status: true
+dependencies: {  }
+id: napo_and_friends
+label: 'Napo and friends'
+renderer: quick_tabs
+options:
+  quick_tabs:
+    class: ''
+    style: tabsbar
+    ajax: false
+hide_empty_tabs: false
+default_tab: 1
+configuration_data:
+  -
+    title: 'Reorder Napo and friends'
+    weight: -10
+    type: view_content
+    content:
+      qtabs_content:
+        options:
+          machine_name: napo_films
+      block_content:
+        options:
+          bid: 'entity_view:node'
+          block_title: ''
+          display_title: false
+      node_content:
+        options:
+          nid: ''
+          view_mode: full
+          hide_title: true
+      view_content:
+        options:
+          vid: napo_and_friends
+          display: page_1
+          args: ''
+  -
+    title: View
+    weight: -9
+    type: view_content
+    content:
+      qtabs_content:
+        options:
+          machine_name: napo_films
+      block_content:
+        options:
+          bid: 'entity_view:node'
+          block_title: ''
+          display_title: false
+      node_content:
+        options:
+          nid: ''
+          view_mode: full
+          hide_title: true
+      view_content:
+        options:
+          vid: napo_and_friends
+          display: page_2
+          args: ''

--- a/config/sync/views.view.napo_and_friends.yml
+++ b/config/sync/views.view.napo_and_friends.yml
@@ -16,6 +16,7 @@ dependencies:
     - slick_views
     - text
     - user
+    - views_slideshow
 id: napo_and_friends
 label: 'Napo and friends'
 module: views
@@ -41,7 +42,7 @@ display:
         type: views_query
         options:
           disable_sql_rewrite: false
-          distinct: false
+          distinct: true
           replica: false
           query_comment: ''
           query_tags: {  }
@@ -388,7 +389,7 @@ display:
       relationships: {  }
       arguments: {  }
       display_extenders: {  }
-      show_admin_links: false
+      show_admin_links: true
     cache_metadata:
       max-age: 0
       contexts:
@@ -432,6 +433,7 @@ display:
         title: false
         access: false
         pager: false
+        arguments: false
       row:
         type: fields
         options:
@@ -549,7 +551,7 @@ display:
         expanded: false
         parent: ''
         weight: 0
-        context: '0'
+        context: '1'
         menu_name: main
       title: 'Reorder Napo''s friends'
       access:
@@ -557,9 +559,11 @@ display:
         options:
           perm: 'edit any napo_friend content'
       pager:
-        type: none
+        type: some
         options:
+          items_per_page: 7
           offset: 0
+      arguments: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -586,6 +590,7 @@ display:
         row: false
         access: false
         sorts: false
+        header: false
       menu:
         type: 'default tab'
         title: View
@@ -919,14 +924,13 @@ display:
         options:
           vanilla: true
           optionset: default
-          skin: ''
+          skin: default
           layout: ''
           caption:
             field_image_2: '0'
             field_image: '0'
             title: '0'
             body: '0'
-            draggableviews: '0'
           optionset_thumbnail: ''
           skin_thumbnail: ''
           thumbnail_position: ''
@@ -943,9 +947,9 @@ display:
           link: ''
           class: ''
           id: ''
-          override: false
+          override: true
           overridables:
-            arrows: '0'
+            arrows: arrows
             autoplay: '0'
             dots: '0'
             draggable: '0'
@@ -981,6 +985,7 @@ display:
           expose:
             label: ''
           plugin_id: standard
+      header: {  }
     cache_metadata:
       max-age: 0
       contexts:
@@ -1008,8 +1013,12 @@ display:
         row: false
         access: false
         sorts: false
+        filters: false
+        filter_groups: false
+        show_admin_links: false
+        header: false
       menu:
-        type: none
+        type: 'default tab'
         title: View
         description: ''
         expanded: false
@@ -1028,6 +1037,71 @@ display:
           items_per_page: 7
           offset: 0
       fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
         field_image_2:
           id: field_image_2
           table: node__field_image
@@ -1156,71 +1230,6 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
-        title:
-          id: title
-          table: node_field_data
-          field: title
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: ''
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: false
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         body:
           id: body
           table: node__body
@@ -1284,46 +1293,91 @@ display:
           field_api_classes: false
           plugin_id: field
       style:
-        type: slick
+        type: slideshow
         options:
-          vanilla: true
-          optionset: default
-          skin: default
-          layout: top
-          caption:
-            field_image: field_image
-            title: title
-            body: body
-            field_image_2: '0'
-          optionset_thumbnail: slider_nav
-          skin_thumbnail: asnavfor
-          thumbnail_position: top
-          thumbnail_caption: title
-          grid: null
-          grid_medium: null
-          grid_small: null
-          visible_items: null
-          preserve_keys: false
-          image: ''
-          thumbnail: field_image_2
-          overlay: ''
-          title: ''
-          link: ''
-          class: ''
-          id: friends
-          override: true
-          overridables:
-            arrows: arrows
-            infinite: infinite
-            variableWidth: variableWidth
-            autoplay: '0'
-            dots: '0'
-            draggable: '0'
-            mouseWheel: '0'
-            randomize: '0'
-          cache: 0
-          current_view_mode: page_3
-          thumbnail_effect: grid
+          row_class: ''
+          default_row_class: true
+          slideshow_skin: default
+          slideshow_type: views_slideshow_cycle
+          views_slideshow_cycle:
+            effect: none
+            transition_advanced: 1
+            timeout: '0'
+            speed: '700'
+            delay: '0'
+            sync: 1
+            random: 0
+            pause: 1
+            pause_on_click: 0
+            action_advanced: 0
+            start_paused: 1
+            remember_slide: 0
+            remember_slide_days: '1'
+            pause_in_middle: 0
+            pause_when_hidden: 0
+            pause_when_hidden_type: full
+            amount_allowed_visible: ''
+            nowrap: 0
+            fixed_height: 1
+            items_per_slide: '1'
+            items_per_slide_first: 0
+            items_per_slide_first_number: '1'
+            wait_for_image_load: 1
+            wait_for_image_load_timeout: '3000'
+            cleartype: 0
+            cleartypenobg: 0
+            advanced_options_choices: activePagerClass
+            advanced_options_entry: ''
+            advanced_options: '{}'
+          widgets:
+            top:
+              views_slideshow_controls:
+                enable: false
+                weight: '1'
+                hide_on_single_slide: '0'
+                type: views_slideshow_controls_text
+              views_slideshow_slide_counter:
+                enable: false
+                weight: '1'
+                hide_on_single_slide: '0'
+              views_slideshow_pager:
+                enable: true
+                weight: '1'
+                hide_on_single_slide: '0'
+                type: views_slideshow_pager_fields
+                views_slideshow_pager_bullets:
+                  views_slideshow_pager_bullets_hover: 0
+                views_slideshow_pager_fields:
+                  views_slideshow_pager_fields_fields:
+                    title: title
+                    field_image_2: field_image_2
+                    field_image: 0
+                    body: 0
+                  views_slideshow_pager_fields_hover: 1
+            bottom:
+              views_slideshow_controls:
+                enable: true
+                weight: '1'
+                hide_on_single_slide: '0'
+                type: views_slideshow_controls_text
+              views_slideshow_slide_counter:
+                enable: false
+                weight: '1'
+                hide_on_single_slide: '0'
+              views_slideshow_pager:
+                enable: false
+                weight: '1'
+                hide_on_single_slide: '0'
+                type: views_slideshow_pager_bullets
+                views_slideshow_pager_bullets:
+                  views_slideshow_pager_bullets_hover: 0
+                views_slideshow_pager_fields:
+                  views_slideshow_pager_fields_fields:
+                    title: 0
+                    field_image_2: 0
+                    field_image: 0
+                    body: 0
+                  views_slideshow_pager_fields_hover: 0
       row:
         type: fields
         options:
@@ -1348,10 +1402,114 @@ display:
           expose:
             label: ''
           plugin_id: standard
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+          group: 1
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            napo_friend: napo_friend
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            '***LANGUAGE_site_default***': '***LANGUAGE_site_default***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      show_admin_links: true
+      header: {  }
+      rendering_language: '***LANGUAGE_language_interface***'
     cache_metadata:
       max-age: -1
       contexts:
-        - 'languages:language_content'
         - 'languages:language_interface'
         - 'user.node_grants:view'
         - user.permissions


### PR DESCRIPTION
Update Napo and friends with slideshow and tabs.
The Views Slideshow module needs to be revised. As it is now it does not save the order in another view when it is reordered.
The patches that fix these cause more issues like duplicated elements.
Views Slideshow module requires these libraries:
[https://www.drupal.org/docs/8/modules/views-slideshow/installation-requirements](https://www.drupal.org/docs/8/modules/views-slideshow/installation-requirements)

- jQuery Cycle 3.x in /libraries/jquery.cycle
- JSON2 in /libraries/json2
- jQuery HoverIntent in /libraries/jquery.hoverIntent
- jQuery Pause in /libraries/jquery.pause
