### PR TITLE
Napo fixes 10

### DIFF
--- a/config/sync/views.view.napo_s_film_episodes.yml
+++ b/config/sync/views.view.napo_s_film_episodes.yml
@@ -1095,6 +1095,59 @@ display:
           hide_alter_empty: true
           counter_start: 1
           plugin_id: counter
+        view_node_1:
+          id: view_node_1
+          table: node
+          field: view_node
+          relationship: none
+          group_type: group
+          admin_label: 'Link to Scene'
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: view
+          output_url_as_text: true
+          absolute: true
+          entity_type: node
+          plugin_id: entity_link
         title:
           id: title
           table: node_field_data
@@ -1106,7 +1159,7 @@ display:
           exclude: true
           alter:
             alter_text: true
-            text: '<a href="{{ arguments.field_napo_film_target_id }} ">Scene 0{{ counter }}: {{ title__value }} </a>'
+            text: '<a href="{{ view_node_1 }}">Scene 0{{ counter }}: {{ title__value }} </a>'
             make_link: false
             path: ''
             absolute: false
@@ -1146,7 +1199,7 @@ display:
           click_sort_column: value
           type: string
           settings:
-            link_to_entity: true
+            link_to_entity: false
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/themes/custom/napo_theme/templates/content/node--lesson--full.html.twig
+++ b/themes/custom/napo_theme/templates/content/node--lesson--full.html.twig
@@ -78,10 +78,8 @@
   ]
 
 %}
-{% set lang = url | split('/')[1] %}
 
-
-<div class="back-button-custom"><a href="/learning-with-napo/napo-for-teachers">{{ 'Back to Napo for teachers' | trans }}</a></div>
+<div class="back-button-custom"><a href="{{ path('view.napo_for_teachers.page') }}">{{ 'Back to Napo for teachers' | trans }}</a></div>
 <article{{ attributes.addClass(classes) }}>
   <div class="page-banner-custom">
     <div class="video-custom" id="videoCustom">
@@ -101,7 +99,7 @@
           {{ 'Do you need help to organise a learning activity in your classroom?' | trans }}
         </div>
         <div class="link-box">
-          <a href="/learning-with-napo/napo-for-teachers/teacher-guidance" target="_blank">{{ 'Find out more here' | trans }}</a>
+          <a href="{{ url('entity.node.canonical', {'node': 407}) }}" target="_blank">{{ 'Find out more here' | trans }}</a>
         </div>
       </div>
     </div>

--- a/themes/custom/napo_theme/templates/field/field--node--field-resources-required--lesson.html.twig
+++ b/themes/custom/napo_theme/templates/field/field--node--field-resources-required--lesson.html.twig
@@ -79,7 +79,7 @@
             <a href="#videoCustom" id="linkToVideoCustom">{{ 'Go to video'|t }}</a>
           </li>
         </ul>
-        <p>{{ 'To download the provided resources, go to'|t }}: <a href="/learning-with-napo/napo-for-teachers/resource-library" target="_blank">{{ 'Resource library'|t }}</a></p>
+        <p>{{ 'To download the provided resources, go to'|t }}: <a href="{{ path('view.resource_library.page') }}" target="_blank">{{ 'Resource library'|t }}</a></p>
     {% if multiple %}
       </div>
     {% endif %}


### PR DESCRIPTION
Fix NAPO Film Safety pays is downloaded in AVI format instead of MP4.
Fix Page not found When clicking on the title of a scene in scene List
Fix link to teacher guidance and resource library