### PR TITLE
Napo fix12

### DIFF
--- a/config/sync/language/bg/views.view.napo_films_index.yml
+++ b/config/sync/language/bg/views.view.napo_films_index.yml
@@ -17,10 +17,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\" or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Гледайте епизодите</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -30,10 +26,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                     <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Гледайте епизодите</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -43,10 +35,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                     <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Гледайте епизодите</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -56,7 +44,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                     <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Гледайте епизодите</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/cs/views.view.napo_films_index.yml
+++ b/config/sync/language/cs/views.view.napo_films_index.yml
@@ -24,10 +24,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                  <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Zobrazit scény</a></div>\r\n{% endif%}\r\n{% endif %}\r\n\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -40,10 +36,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                  <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Zobrazit scény</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -56,10 +48,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                  <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Zobrazit scény</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -72,7 +60,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                  <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Zobrazit scény</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/da/views.view.napo_films_index.yml
+++ b/config/sync/language/da/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n             <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Se episoder</a></div>\r\n{% endif%}\r\n{% endif %}\r\n\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n             <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n             <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Se episoder</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n             <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Se episoder</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n             <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Se episoder</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/de/views.view.napo_films_index.yml
+++ b/config/sync/language/de/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n           <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Episoden ansehen</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n           <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Episoden ansehen</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n           <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Episoden ansehen</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n           <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Episoden ansehen</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/el/views.view.napo_films_index.yml
+++ b/config/sync/language/el/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Προβολή επεισοδίων</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Προβολή επεισοδίων</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n      {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Προβολή επεισοδίων</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Προβολή επεισοδίων</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/es/views.view.napo_films_index.yml
+++ b/config/sync/language/es/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ver episodios</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n    {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ver episodios</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ver episodios</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ver episodios</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/et/views.view.napo_films_index.yml
+++ b/config/sync/language/et/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vaadake episoode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vaadake episoode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vaadake episoode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n        <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vaadake episoode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/fi/views.view.napo_films_index.yml
+++ b/config/sync/language/fi/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Katsele jaksot</a></div>\r\n{% endif%}\r\n{% endif %}\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Katsele jaksot</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Katsele jaksot</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Katsele jaksot</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/fr/views.view.napo_films_index.yml
+++ b/config/sync/language/fr/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Voir les épisodes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n             <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Voir les épisodes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Voir les épisodes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Voir les épisodes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/hr/views.view.napo_films_index.yml
+++ b/config/sync/language/hr/views.view.napo_films_index.yml
@@ -21,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Prikaži epizode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -37,10 +33,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Prikaži epizode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -53,10 +45,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n     {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Prikaži epizode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -69,7 +57,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Prikaži epizode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/hu/views.view.napo_films_index.yml
+++ b/config/sync/language/hu/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n  <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Jelenetek megtekintése</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n    {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n  <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Jelenetek megtekintése</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n  <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Jelenetek megtekintése</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n  <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Jelenetek megtekintése</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/is/views.view.napo_films_index.yml
+++ b/config/sync/language/is/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Skoða þætti</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Skoða þætti</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n     {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Skoða þætti</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Skoða þætti</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/it/views.view.napo_films_index.yml
+++ b/config/sync/language/it/views.view.napo_films_index.yml
@@ -12,10 +12,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Guarda episodi</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -25,10 +21,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Guarda episodi</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -38,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Guarda episodi</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -51,7 +39,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Guarda episodi</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/lt/views.view.napo_films_index.yml
+++ b/config/sync/language/lt/views.view.napo_films_index.yml
@@ -20,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Žiūrėti epizodus</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -36,10 +32,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n   {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Žiūrėti epizodus</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -52,10 +44,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n   {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Žiūrėti epizodus</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n        <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -68,7 +56,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Žiūrėti epizodus</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/lv/views.view.napo_films_index.yml
+++ b/config/sync/language/lv/views.view.napo_films_index.yml
@@ -18,10 +18,6 @@ display:
         url_1:
           alter:
             text: 'Skatīties filmiņu'
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -34,10 +30,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Skatīt epizodes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -50,10 +42,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Skatīt epizodes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -66,10 +54,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Skatīt epizodes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_1:
     display_options:
       title: 'Napo filmas'

--- a/config/sync/language/mt/views.view.napo_films_index.yml
+++ b/config/sync/language/mt/views.view.napo_films_index.yml
@@ -20,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ara l-episodji</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -36,10 +32,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ara l-episodji</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -52,10 +44,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ara l-episodji</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -68,7 +56,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ara l-episodji</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/nl/views.view.napo_films_index.yml
+++ b/config/sync/language/nl/views.view.napo_films_index.yml
@@ -8,10 +8,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Afleveringen bekijken</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -21,10 +17,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n             <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n   {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Afleveringen bekijken</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -34,10 +26,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n   {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Afleveringen bekijken</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -47,7 +35,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Afleveringen bekijken</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/no/views.view.napo_films_index.yml
+++ b/config/sync/language/no/views.view.napo_films_index.yml
@@ -11,10 +11,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vis episoder</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -24,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vis episoder</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -37,10 +29,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n     {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vis episoder</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -50,7 +38,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vis episoder</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/pl/views.view.napo_films_index.yml
+++ b/config/sync/language/pl/views.view.napo_films_index.yml
@@ -20,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Zobacz odcinki</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -36,10 +32,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n     {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Zobacz odcinki</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -52,10 +44,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n   {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Zobacz odcinki</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -68,7 +56,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Zobacz odcinki</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/pt-pt/views.view.napo_films_index.yml
+++ b/config/sync/language/pt-pt/views.view.napo_films_index.yml
@@ -11,10 +11,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ver episódios</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -24,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ver episódios</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -37,10 +29,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n    {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ver episódios</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -50,7 +38,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Ver episódios</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/ro/views.view.napo_films_index.yml
+++ b/config/sync/language/ro/views.view.napo_films_index.yml
@@ -20,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vedeți episoadele</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -36,10 +32,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vedeți episoadele</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -52,10 +44,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n    {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vedeți episoadele</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n        <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -68,7 +56,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n       <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Vedeți episoadele</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/sk/views.view.napo_films_index.yml
+++ b/config/sync/language/sk/views.view.napo_films_index.yml
@@ -20,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Prezrieť epizódy</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -36,10 +32,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Prezrieť epizódy</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -52,10 +44,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n      {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Prezrieť epizódy</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -68,7 +56,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Prezrieť epizódy</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/sl/views.view.napo_films_index.yml
+++ b/config/sync/language/sl/views.view.napo_films_index.yml
@@ -20,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Glej epizode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -36,10 +32,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n      {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Glej epizode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -52,10 +44,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Glej epizode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -68,7 +56,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Glej epizode</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/language/sv/views.view.napo_films_index.yml
+++ b/config/sync/language/sv/views.view.napo_films_index.yml
@@ -11,10 +11,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Visa avsnitt</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n</div>\r\n"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_3:
     display_options:
       fields:
@@ -24,10 +20,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n              <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Visa avsnitt</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_4:
     display_options:
       fields:
@@ -37,10 +29,6 @@ display:
         nothing:
           alter:
             text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Visa avsnitt</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n         <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''
   page_list:
     display_options:
       fields:
@@ -50,7 +38,3 @@ display:
         nothing:
           alter:
             text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n  {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n<div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">Visa avsnitt</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n<a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
-      filters:
-        search_api_fulltext:
-          group_info:
-            description: ''

--- a/config/sync/views.view.napo_films_index.yml
+++ b/config/sync/views.view.napo_films_index.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_combined_tags
     - field.storage.node.field_image
+    - field.storage.node.field_main_tag
     - field.storage.node.field_publication_date
     - field.storage.node.field_tags
     - field.storage.node.field_video_type
@@ -1607,6 +1608,94 @@ display:
           multi_type: separator
           multi_separator: ', '
           plugin_id: search_api
+        field_main_tag:
+          id: field_main_tag
+          table: search_api_index_default_multilingual_node_index
+          field: field_main_tag
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '<a href="{{path}}/napos-films/films?f[0]=categories:{{ field_main_tag__target_id }}" >{{ field_main_tag }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              main_category:
+                display_method: label
+                view_mode: default
+              nace_codes:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+                view_mode: default
+              target_ages:
+                display_method: label
+                view_mode: default
+              thesaurus:
+                display_method: label
+                view_mode: default
+              video_type:
+                display_method: label
+          plugin_id: search_api_field
         field_combined_tags:
           id: field_combined_tags
           table: search_api_index_default_multilingual_node_index
@@ -2182,7 +2271,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n   {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">View scenes</a></div>\r\n{% endif%}\r\n    </div>\r\n</div>\r\n"
+            text: "<div class=\"item\">\r\n    <div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n\r\n</div>\r\n</div>\r\n         <div class=\"cart\">{{ ncc_download }}</div>\r\n    </div>\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{field_main_tag}} | {{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n   {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">View scenes</a></div>\r\n{% endif%}\r\n    </div>\r\n</div>\r\n"
             make_link: false
             path: ''
             absolute: false
@@ -2253,6 +2342,7 @@ display:
       tags:
         - 'config:field.storage.node.field_combined_tags'
         - 'config:field.storage.node.field_image'
+        - 'config:field.storage.node.field_main_tag'
         - 'config:field.storage.node.field_publication_date'
         - 'config:field.storage.node.field_tags'
         - 'config:field.storage.node.field_video_type'
@@ -2981,6 +3071,94 @@ display:
           multi_type: separator
           multi_separator: ', '
           plugin_id: search_api
+        field_main_tag:
+          id: field_main_tag
+          table: search_api_index_default_multilingual_node_index
+          field: field_main_tag
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '<a href="{{path}}/napos-films/films?f[0]=categories:{{ field_main_tag__target_id }}" >{{ field_main_tag }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              main_category:
+                display_method: label
+                view_mode: default
+              nace_codes:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+                view_mode: default
+              target_ages:
+                display_method: label
+                view_mode: default
+              thesaurus:
+                display_method: label
+                view_mode: default
+              video_type:
+                display_method: label
+          plugin_id: search_api_field
         field_combined_tags:
           id: field_combined_tags
           table: search_api_index_default_multilingual_node_index
@@ -3556,7 +3734,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n             <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\" or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">View scenes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
+            text: "<div class=\"item\">\r\n<div class=\"napo-film-title-container\">\r\n         <h3>{{title}}</h3>\r\n         <div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n             {% for link in uri|split(',') %}\r\n             <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n            {% endfor %}\r\n         </div>\r\n</div>\r\n         \r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n</div>\r\n\r\n    <div class=\"napo-film-list-image\">\r\n        {{field_image}}\r\n    </div>\r\n    <div class=\"napo-film-content-container\">\r\n        <div class=\"grid date\">{{field_publication_date}}</div>\r\n        <p class=\"grid text\">{{processed}}</p>\r\n        <div class=\"grid tags\">{{field_main_tag}} | {{ field_combined_tags }}</div>\r\n        <div class=\"view-video\">{{ url_1 }}</div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\" or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">View scenes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n    </div>\r\n\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -3627,6 +3805,7 @@ display:
       tags:
         - 'config:field.storage.node.field_combined_tags'
         - 'config:field.storage.node.field_image'
+        - 'config:field.storage.node.field_main_tag'
         - 'config:field.storage.node.field_publication_date'
         - 'config:field.storage.node.field_tags'
         - 'config:field.storage.node.field_video_type'
@@ -4360,6 +4539,94 @@ display:
           multi_type: separator
           multi_separator: ', '
           plugin_id: search_api
+        field_main_tag:
+          id: field_main_tag
+          table: search_api_index_default_multilingual_node_index
+          field: field_main_tag
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '<a href="{{path}}/napos-films/films?f[0]=categories:{{ field_main_tag__target_id }}" >{{ field_main_tag }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              main_category:
+                display_method: label
+                view_mode: default
+              nace_codes:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+                view_mode: default
+              target_ages:
+                display_method: label
+                view_mode: default
+              thesaurus:
+                display_method: label
+                view_mode: default
+              video_type:
+                display_method: label
+          plugin_id: search_api_field
         field_combined_tags:
           id: field_combined_tags
           table: search_api_index_default_multilingual_node_index
@@ -4935,7 +5202,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{ field_combined_tags }}</div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">View scenes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n          <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
+            text: "<div class=\"item {{ field_video_type }}\">\r\n  <div class=\"cart\">{{ ncc_download }}</div>\r\n  <div class=\"napo-film-list-image\">{{field_image}}</div>\r\n  <div class=\"group-right\">\r\n    <h3>{{title}}</h3>\r\n    <div>{{field_publication_date}}</div>\r\n    <p>{{processed}}</p>\r\n    <div class=\"napo-film-list-details-container\">\r\n      <div class=\"\">{{field_main_tag}} | {{ field_combined_tags }}</div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\"  or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">View scenes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n      <div class=\"view-video\">{{ url_1 }}</div>\r\n      <div class=\"download-video\">\r\n        <div class=\"download-items\">\r\n        {% for link in uri|split(',') %}\r\n          <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n        {% endfor %}\r\n        </div>\r\n      </div>\r\n  </div>\r\n</div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -5023,6 +5290,7 @@ display:
       tags:
         - 'config:field.storage.node.field_combined_tags'
         - 'config:field.storage.node.field_image'
+        - 'config:field.storage.node.field_main_tag'
         - 'config:field.storage.node.field_publication_date'
         - 'config:field.storage.node.field_tags'
         - 'config:field.storage.node.field_video_type'
@@ -5755,6 +6023,94 @@ display:
           multi_type: separator
           multi_separator: ', '
           plugin_id: search_api
+        field_main_tag:
+          id: field_main_tag
+          table: search_api_index_default_multilingual_node_index
+          field: field_main_tag
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '<a href="{{path}}/napos-films/films?f[0]=categories:{{ field_main_tag__target_id }}" >{{ field_main_tag }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          field_rendering: true
+          fallback_handler: search_api_entity
+          fallback_options:
+            link_to_item: false
+            use_highlighting: false
+            multi_type: separator
+            multi_separator: ', '
+            display_methods:
+              main_category:
+                display_method: label
+                view_mode: default
+              nace_codes:
+                display_method: label
+                view_mode: default
+              tags:
+                display_method: label
+                view_mode: default
+              target_ages:
+                display_method: label
+                view_mode: default
+              thesaurus:
+                display_method: label
+                view_mode: default
+              video_type:
+                display_method: label
+          plugin_id: search_api_field
         field_combined_tags:
           id: field_combined_tags
           table: search_api_index_default_multilingual_node_index
@@ -6330,7 +6686,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{ field_combined_tags }} </div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\" or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">View scenes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
+            text: "<div class=\"item\">\r\n<div class=\"cart\">{{ ncc_download }}</div>\r\n<div class=\"napo-film-list-image\">{{field_image}}</div>\r\n<div class=\"group-right\">\r\n<h3>{{title}}</h3>\r\n<div>{{field_publication_date}}</div>\r\n<p>{{processed}}</p>\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"\">{{field_main_tag}} | {{ field_combined_tags }} </div>\r\n       {% if field_video_type  == 'Film video' %}\r\n          {% if nid  == \"86\"  or  nid  == \"95\" or  nid  == \"104\"  or  nid  == \"113\"  or  nid  == \"124\"  or  nid  == \"134\" or  nid  == \"144\"  or  nid  == \"153\"  or  nid  == \"166\"\r\n           or  nid  == \"174\"  or  nid  == \"193\"  or  nid  == \"183\"  or  nid  == \"203\" or  nid  == \"212\"  or  nid  == \"223\"  or  nid  == \"270\"  or  nid  == \"306\"      \r\n          or  nid  == \"324\"  or  nid  == \"333\"  or  nid  == \"433\"  or  nid  == \"446\"  %}\r\n                      <div class=\"view-scenes\"><a href=\"/{{langcode}}/napos-films/{{url_2 }}/view-scenes\">View scenes</a></div>\r\n{% endif%}\r\n{% endif %}\r\n<div class=\"view-video\">{{ url_1 }}</div>\r\n<div class=\"download-video\">\r\n<div class=\"download-items\">\r\n{% for link in uri|split(',') %}\r\n <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{ link }}</a>\r\n{% endfor %}\r\n</div>\r\n</div>\r\n\r\n</div>\r\n</div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -6418,6 +6774,7 @@ display:
       tags:
         - 'config:field.storage.node.field_combined_tags'
         - 'config:field.storage.node.field_image'
+        - 'config:field.storage.node.field_main_tag'
         - 'config:field.storage.node.field_publication_date'
         - 'config:field.storage.node.field_tags'
         - 'config:field.storage.node.field_video_type'

--- a/config/sync/views.view.napo_s_film_episodes.yml
+++ b/config/sync/views.view.napo_s_film_episodes.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_combined_tags
     - field.storage.node.field_image
+    - field.storage.node.field_main_tag
     - field.storage.node.field_publication_date
     - field.storage.node.field_video
     - image.style.large
@@ -1277,6 +1278,69 @@ display:
           separator: ', '
           field_api_classes: false
           plugin_id: field
+        field_main_tag:
+          id: field_main_tag
+          table: node__field_main_tag
+          field: field_main_tag
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: true
+            text: '<a href="{{path}}/napos-films/films?f[0]=categories:{{ field_main_tag__target_id }}" >{{ field_main_tag }}</a>'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
         field_combined_tags:
           id: field_combined_tags
           table: node__field_combined_tags
@@ -1467,7 +1531,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<h3> <b>{{ title }}</b></h3>\r\n{{ field_publication_date }} \r\n<div class=\"episode-list-details-container\">\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"tags\">{{ field_combined_tags }} </div>\r\n<div class=\"buttons\">\r\n<div class=\"view-video\">{{ view_node }}</div>\r\n<div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n                {% for link in field_video|split(',') %}\r\n                <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{link}}</a>\r\n                {% endfor %}\r\n            </div>\r\n        </div>\r\n</div>\r\n</div>\r\n</div>"
+            text: "<h3> <b>{{ title }}</b></h3>\r\n{{ field_publication_date }} \r\n<div class=\"episode-list-details-container\">\r\n<div class=\"napo-film-list-details-container\">\r\n<div class=\"tags\">{{field_main_tag}} | {{ field_combined_tags }} </div>\r\n<div class=\"buttons\">\r\n<div class=\"view-video\">{{ view_node }}</div>\r\n<div class=\"download-video\">\r\n            <div class=\"download-items\">\r\n                {% for link in field_video|split(',') %}\r\n                <a target=\"_blank\" href=\"/napos-films/{{ nid }}/video/download?number={{loop.index-1}}\">{{link}}</a>\r\n                {% endfor %}\r\n            </div>\r\n        </div>\r\n</div>\r\n</div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false
@@ -1754,5 +1818,6 @@ display:
       tags:
         - 'config:field.storage.node.field_combined_tags'
         - 'config:field.storage.node.field_image'
+        - 'config:field.storage.node.field_main_tag'
         - 'config:field.storage.node.field_publication_date'
         - 'config:field.storage.node.field_video'

--- a/themes/custom/napo_theme/napo_theme.theme
+++ b/themes/custom/napo_theme/napo_theme.theme
@@ -73,9 +73,12 @@ function napo_theme_preprocess_node(&$variables) {
         ->getValue()[0]['value'];
     }
     if ($default_youtube == NULL) {
-      $default_youtube = $variables['node']->getUntranslated()
-        ->get('field_youtube')
-        ->getValue()[0]['value'];
+      $originalNode = $default_youtube = $variables['node']->getUntranslated();
+      if(isset($originalNode->get('field_youtube')->getValue()[0]['value'])){
+        $default_youtube = $variables['node']->getUntranslated()
+          ->get('field_youtube')
+          ->getValue()[0]['value'];
+      }
     }
 
     if (count($variables['node']->get('field_video')->getValue()) == 0) {


### PR DESCRIPTION
1. Run these queries in the napo stg database. [lv_video.zip](https://github.com/EU-OSHA/napo-D9/files/7857141/lv_video.zip)
2. Clear all caches
3. Reindex items in multilingual_node_index

MDR-4954 - main tag not displayed on the list of categories of the video (views).
Relates to MDR-4930 to re-index after running a script to update the (without this change it gives an error when reindexing)